### PR TITLE
Possible solution for #6

### DIFF
--- a/hybridauth/inc/hybridauth.functions.php
+++ b/hybridauth/inc/hybridauth.functions.php
@@ -52,7 +52,7 @@ function hybridauth_complete_profile($user_profile, $ruser = array(), $provider_
 			$ruser['user_email'] = $user_profile->identifier . '@'. $provider_code . '.com';
 			if(mb_strlen($ruser['user_email']) > 64 || !cot_check_email($ruser['user_email']))
 			{
-				$ruser['user_email'] = md5($user_profile->identifier.microtime().$provider_code) . '@' . $provider_code . '.com';
+				$ruser['user_email'] = md5($user_profile->identifier.microtime()) . '@' . $provider_code . '.com';
 			}
 
 		}

--- a/hybridauth/inc/hybridauth.functions.php
+++ b/hybridauth/inc/hybridauth.functions.php
@@ -49,7 +49,8 @@ function hybridauth_complete_profile($user_profile, $ruser = array(), $provider_
 		elseif ($generate_emails)
 		{
 			// Provider does not provide user emails
-			$ruser['user_email'] = $user_profile->identifier . '@' . $provider_code . '.com';
+			$ruser['user_email'] = md5($user_profile->identifier.microtime().$provider_code) . '@' . $provider_code . '.com';
+
 		}
 	}
 

--- a/hybridauth/inc/hybridauth.functions.php
+++ b/hybridauth/inc/hybridauth.functions.php
@@ -49,7 +49,11 @@ function hybridauth_complete_profile($user_profile, $ruser = array(), $provider_
 		elseif ($generate_emails)
 		{
 			// Provider does not provide user emails
-			$ruser['user_email'] = md5($user_profile->identifier.microtime().$provider_code) . '@' . $provider_code . '.com';
+			$ruser['user_email'] = $user_profile->identifier . '@'. $provider_code . '.com';
+			if(mb_strlen($ruser['user_email']) > 64 || !cot_check_email($ruser['user_email']))
+			{
+				$ruser['user_email'] = md5($user_profile->identifier.microtime().$provider_code) . '@' . $provider_code . '.com';
+			}
 
 		}
 	}


### PR DESCRIPTION
Turns `http://steamcommunity.com/openid/id/930561197961093972@steam.com` to `49f68a5c8493ec2c0bf489821c21fc3b@steam.com` when generating an email address for a user's profile if `$user_profile->identifier.'@'.$provider_code.'.com'` doesn't pass `cot_check_email()`

Other possible solutions I can think of:
- Generate a hash only for email address for auto-register accounts and if auto-register isn't on, force the user to provide an email address if `$user_profile->identifier.'@'.$provider_code.'.com'` doesn't pass `cot_check_email()`
- Individual parsing for specific providers
- Combination of time and decent length random string instead of hash
